### PR TITLE
Add simple Flask login app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# easywaiter
+# Easywaiter Flask App
+
+This repository contains a minimal Flask application with a simple login system.
+User credentials are stored in a plain text file `users.txt` in the format `username:password`.
+
+## Setup
+1. Install dependencies (Flask):
+   ```bash
+   pip install flask
+   ```
+   If you do not have network access, make sure Flask is available in your environment.
+
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+   The app will start in debug mode on `http://localhost:5000`.
+
+## Default Credentials
+An example user is included:
+- **Username:** `admin`
+- **Password:** `password`
+
+Add new users by appending lines in the same `username:password` format to `users.txt`.

--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ User credentials are stored in a plain text file `users.txt` in the format `user
 
 2. Run the application:
    ```bash
-   python app.py
+   ./start.sh
    ```
+   This script launches `app.py` from its own directory, so you can
+   execute it whether or not you are currently in the repository folder.
    The app will start in debug mode on `http://localhost:8080`.
+
+   If you prefer to run `python app.py` directly, make sure you are in
+   the same directory as `app.py` to avoid "file not found" errors.
 
 ## Default Credentials
 An example user is included:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Easywaiter Flask App
 
 This repository contains a minimal Flask application with a simple login system.
-User credentials are stored in a plain text file `users.txt` in the format `username:password`.
+User credentials are stored in a plain text file `users.txt` in the format `username:hashed_password`.
 
 ## Setup
 1. Install dependencies (Flask):
@@ -21,4 +21,13 @@ An example user is included:
 - **Username:** `admin`
 - **Password:** `password`
 
-Add new users by appending lines in the same `username:password` format to `users.txt`.
+Passwords in `users.txt` are hashed using Werkzeug. To add a new user run:
+```bash
+python - <<'PY'
+from werkzeug.security import generate_password_hash
+username = 'newuser'
+password = 'mypassword'
+print(f"{username}:{generate_password_hash(password)}")
+PY
+```
+Append the printed line to `users.txt`.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ User credentials are stored in a plain text file `users.txt` in the format `user
    ```bash
    python app.py
    ```
-   The app will start in debug mode on `http://localhost:5000`.
+   The app will start in debug mode on `http://localhost:8080`.
 
 ## Default Credentials
 An example user is included:

--- a/app.py
+++ b/app.py
@@ -59,4 +59,4 @@ def logout():
     return redirect(url_for('login'))
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, port=8080)

--- a/app.py
+++ b/app.py
@@ -1,0 +1,62 @@
+from flask import Flask, render_template_string, request, redirect, url_for, session
+import os
+
+app = Flask(__name__)
+app.secret_key = 'replace-with-a-secure-random-key'
+
+USERS_FILE = 'users.txt'
+
+# Helper function to load users from the text file
+
+def load_users():
+    users = {}
+    if os.path.exists(USERS_FILE):
+        with open(USERS_FILE, 'r') as f:
+            for line in f:
+                line = line.strip()
+                if not line or ':' not in line:
+                    continue
+                username, password = line.split(':', 1)
+                users[username] = password
+    return users
+
+@app.route('/')
+def index():
+    if 'username' in session:
+        return render_template_string('''
+            <h1>Vítejte {{username}}!</h1>
+            <a href="{{ url_for('logout') }}">Odhlásit</a>
+        ''', username=session['username'])
+    return redirect(url_for('login'))
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        username = request.form.get('username', '')
+        password = request.form.get('password', '')
+        users = load_users()
+        if users.get(username) == password:
+            session['username'] = username
+            return redirect(url_for('index'))
+        else:
+            error = 'Neplatné uživatelské jméno nebo heslo.'
+    return render_template_string('''
+        <h2>Přihlášení</h2>
+        {% if error %}<p style="color:red;">{{error}}</p>{% endif %}
+        <form method="post">
+            <label>Uživatel:</label>
+            <input type="text" name="username" required><br>
+            <label>Heslo:</label>
+            <input type="password" name="password" required><br>
+            <input type="submit" value="Přihlásit">
+        </form>
+    ''', error=error)
+
+@app.route('/logout')
+def logout():
+    session.pop('username', None)
+    return redirect(url_for('login'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, render_template_string, request, redirect, url_for, session
+from werkzeug.security import generate_password_hash, check_password_hash
 import os
 
 app = Flask(__name__)
@@ -9,6 +10,7 @@ USERS_FILE = 'users.txt'
 # Helper function to load users from the text file
 
 def load_users():
+    """Return a dict of username to hashed password."""
     users = {}
     if os.path.exists(USERS_FILE):
         with open(USERS_FILE, 'r') as f:
@@ -16,9 +18,18 @@ def load_users():
                 line = line.strip()
                 if not line or ':' not in line:
                     continue
-                username, password = line.split(':', 1)
-                users[username] = password
+                username, hashed = line.split(':', 1)
+                users[username] = hashed
     return users
+
+
+def verify_credentials(username: str, password: str) -> bool:
+    """Check provided credentials against the stored hash."""
+    users = load_users()
+    hashed = users.get(username)
+    if not hashed:
+        return False
+    return check_password_hash(hashed, password)
 
 @app.route('/')
 def index():
@@ -35,8 +46,7 @@ def login():
     if request.method == 'POST':
         username = request.form.get('username', '')
         password = request.form.get('password', '')
-        users = load_users()
-        if users.get(username) == password:
+        if verify_credentials(username, password):
             session['username'] = username
             return redirect(url_for('index'))
         else:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Run the Flask app from the directory of this script so it works from any location.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec python3 "$SCRIPT_DIR/app.py" "$@"

--- a/users.txt
+++ b/users.txt
@@ -1,0 +1,1 @@
+admin:password

--- a/users.txt
+++ b/users.txt
@@ -1,1 +1,2 @@
-admin:password
+# username:hashed_password
+admin:pbkdf2:sha256:260000$31323334353637386162636465666768$da41f93a122fd1e72d7e6f5071fcef374dbb1d96bc09fdfbb9ac436533ebbe07


### PR DESCRIPTION
## Summary
- add a minimal Flask app with a login page
- store credentials in `users.txt`
- document setup steps and default credentials

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_b_684f089441c48327942c5c09a070cd04